### PR TITLE
🚚 Define canonical URL

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -7,6 +7,7 @@
     <title>Brintonium.com</title>
     <meta name="description" content="Brintonium.com home page">
     <meta name="author" content="Connor Brinton">
+    <link rel="canonical" href="https://brintonium.com/" />
 
     <!-- Styles to make sure the PDF takes up the entire viewport -->
     <style>


### PR DESCRIPTION
These changes define the canonical URL for the site, to help search engines know which URL should be preferred between brintonium.com and connorbrinton.com (which currently have duplicate content).